### PR TITLE
Added "marvel_watch" to calculate the number of marvel indexes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
   - 1.9.3
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ A plugin to monitor and restrict the amount of running Opsworks agents.
 A plugin for watching the statistics of an ElasticSearch snapshot.
 
 
+## [Marvel Watch](marvel_watch)
+
+A plugin for watching the number of marvel indexes.
+
+
 ## License
 
 [LGPG-3.0](http://www.gnu.org/licenses/lgpl-3.0.html) License.

--- a/marvel_watch/README.md
+++ b/marvel_watch/README.md
@@ -1,0 +1,24 @@
+# Marvel Watch <sub><sub>by [Infopark](http://www.infopark.com) ![Infopark](../infopark.png)</sub></sub>
+
+Scout-Plugin for watching the number of marvel indexes.
+
+
+## Installation
+
+* Copy [the source](https://raw.github.com/infopark/scout-plugins/master/marvel_watch/marvel_watch.rb)
+* Create a new private plugin in Scout-GUI
+* Paste the code
+
+Refer to [https://scoutapp.com/info/creating_a_plugin](https://scoutapp.com/info/creating_a_plugin)
+
+## Usage
+
+### Metrics
+
+* `number_of_marvel_indexes` - How many index names contain the word `marvel`.
+
+## License
+
+[LGPG-3.0](http://www.gnu.org/licenses/lgpl-3.0.html) License.
+Copyright 2015 Infopark AG.
+http://www.infopark.com

--- a/marvel_watch/marvel_watch.rb
+++ b/marvel_watch/marvel_watch.rb
@@ -1,0 +1,14 @@
+require 'scout'
+require 'json'
+
+class MarvelWatch < Scout::Plugin
+  def build_report
+    uri = URI.parse('http://localhost:9200/_aliases')
+    response = JSON.parse(Net::HTTP.get(uri))
+    marvel_indexes = response.keys.grep(/marvel/)
+
+    report({
+      number_of_marvel_indexes: marvel_indexes.length
+    })
+  end
+end

--- a/marvel_watch/spec/marvel_watch_spec.rb
+++ b/marvel_watch/spec/marvel_watch_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require_relative "../marvel_watch"
+
+describe MarvelWatch do
+  let(:plugin) { MarvelWatch.new(nil, {}, {}) }
+  let(:report) { plugin.run[:reports].first }
+
+  it "reports the number of marvel indexes" do
+    expect(Net::HTTP).to receive(:get).and_return('{
+      ".marvel-2015.03.04" : { "aliases" : { } },
+      ".marvel-2015.02.24" : { "aliases" : { } },
+      "crm_dev_1" : { "aliases" : { } },
+      ".marvel-kibana" : { "aliases" : { } },
+      "crm_dev" : { "aliases" : { } }
+    }')
+
+    expect(report[:number_of_marvel_indexes]).to eq(3)
+  end
+end


### PR DESCRIPTION
Marvel creates a new index each day. Those indexes are not auto-deleted. So unwatched, they can litter the hard drive with "garbage". This Plugin only watches, how many marvel indexes there are.