### PR TITLE
Use "aws-sdk-v1" instead of "aws-sdk" to avoid version 2.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk', '~> 1.9.5'
+gem 'aws-sdk-v1'
 gem 'pry'
 gem 'rspec', '~> 3'
 gem 'scout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.9.5)
+    aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
     coderay (1.0.9)
     diff-lcs (1.2.5)
     elif (0.1.0)
-    json (1.8.1)
+    json (1.8.2)
     method_source (0.8.2)
-    mini_portile (0.6.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -33,13 +32,12 @@ GEM
       elif
     slop (3.4.6)
     timecop (0.7.1)
-    uuidtools (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (~> 1.9.5)
+  aws-sdk-v1
   pry
   rspec (~> 3)
   scout

--- a/elbenwald/elbenwald.rb
+++ b/elbenwald/elbenwald.rb
@@ -15,7 +15,7 @@ class Elbenwald < Scout::Plugin
     default: ~/elbenwald.error.log
   EOS
 
-  needs 'aws-sdk'
+  needs 'aws-sdk-v1'
   needs 'yaml'
 
   def build_report

--- a/swf_tasks/swf_tasks.rb
+++ b/swf_tasks/swf_tasks.rb
@@ -112,7 +112,7 @@ class LastEvent
 end
 
 class SwfTasks < Scout::Plugin
-  needs 'aws-sdk'
+  needs 'aws-sdk-v1'
   needs 'yaml'
   needs 'json'
 


### PR DESCRIPTION
Version 2.x of "aws-sdk" is no longer compatible with "aws-sdk" 1.x. One should use "aws-sdk-v1" instead.

Details see https://github.com/aws/aws-sdk-ruby/tree/aws-sdk-v1#installation